### PR TITLE
modbus: Don't reset registered counter on each metric 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ script:
 
         - go install
 
-        - go test ./...
+        - make test

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,6 @@ $(GOLANGCI_LINT):
 lint: $(GOLANGCI_LINT)
 	GO111MODULE=on $(GO) list -e -compiled -test=true -export=false -deps=true -find=false -tags= -- ./... > /dev/null
 	GO111MODULE=on $(GOLANGCI_LINT) run $(GOLANGCI_LINT_OPTS) $(pkgs)
+
+test:
+	go test ./...

--- a/config/config.go
+++ b/config/config.go
@@ -117,8 +117,8 @@ func (t *ModbusDataType) validate() error {
 		return fmt.Errorf("expected data type not to be nil")
 	}
 
-	for _, possibelType := range possibleModbusDataTypes {
-		if *t == possibelType {
+	for _, possibleType := range possibleModbusDataTypes {
+		if *t == possibleType {
 			return nil
 		}
 	}
@@ -148,8 +148,8 @@ func (t *MetricType) validate() error {
 		return fmt.Errorf("expected metric type not to be nil")
 	}
 
-	for _, possibelType := range possibleMetricTypes {
-		if *t == possibelType {
+	for _, possibleType := range possibleMetricTypes {
+		if *t == possibleType {
 			return nil
 		}
 	}

--- a/modbus/modbus.go
+++ b/modbus/modbus.go
@@ -57,7 +57,7 @@ func (e *Exporter) Scrape(targetAddress, moduleName string) (prometheus.Gatherer
 
 	// TODO: Not a nice way of checking whether the module was found.
 	if module.Name == "" {
-		return nil, fmt.Errorf("failed to find %v in config", moduleName)
+		return nil, fmt.Errorf("failed to find '%v' in config", moduleName)
 	}
 
 	protocol, err := config.CheckPortTarget(targetAddress)
@@ -183,8 +183,6 @@ func registerMetrics(reg prometheus.Registerer, moduleName string, metrics []met
 				registeredCounters[m.Name] = collector
 			}
 
-			// Just to make sure.
-			collector.Reset()
 			collector.With(m.Labels).Add(m.Value)
 		}
 


### PR DESCRIPTION
Calling `Reset` on a counter resets all metrics within the metric
family. Even though nice for savety reasons, this deduplicates by metric
name, thus prohibiting two metrics with the same name and label keys to
be exposed in the final output.