### PR TITLE
modbus_exporter: Move metrics port to :9602

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Usage of ./modbus_exporter:
   -config.file string
     	Sets the configuration file. (default "modbus.yml")
   -modbus-listen-address string
-    	The address to listen on for HTTP requests exposing modbus metrics. (default ":9010")
+    	The address to listen on for HTTP requests exposing modbus metrics. (default ":9602")
   -telemetry-listen-address string
     	The address to listen on for HTTP requests exposing telemetry metrics about the exporter itself. (default ":9011")
 ```

--- a/modbus_exporter.go
+++ b/modbus_exporter.go
@@ -30,16 +30,14 @@ import (
 	"github.com/lupoDharkael/modbus_exporter/modbus"
 )
 
-var (
-	modbusAddress = flag.String("modbus-listen-address", ":9010",
-		"The address to listen on for HTTP requests exposing modbus metrics.")
-	telemetryAddress = flag.String("telemetry-listen-address", ":9011",
-		"The address to listen on for HTTP requests exposing telemetry metrics about the exporter itself.")
-	configFile = flag.String("config.file", "modbus.yml",
-		"Sets the configuration file.")
-)
-
 func main() {
+	modbusAddress := flag.String("modbus-listen-address", ":9602",
+		"The address to listen on for HTTP requests exposing modbus metrics.")
+	telemetryAddress := flag.String("telemetry-listen-address", ":9011",
+		"The address to listen on for HTTP requests exposing telemetry metrics about the exporter itself.")
+	configFile := flag.String("config.file", "modbus.yml",
+		"Sets the configuration file.")
+
 	flag.Parse()
 
 	telemetryRegistry := prometheus.NewRegistry()

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -13,4 +13,4 @@ scrape_configs:
       - source_labels: [__param_target]
         target_label: instance
       - target_label: __address__
-        replacement: 127.0.0.1:9010  # The modbus exporter's real hostname:port.
+        replacement: 127.0.0.1:9602  # The modbus exporter's real hostname:port.


### PR DESCRIPTION
The previous port 9010 is not within the Prometheus exporter port range
(see [1]). Adding the modbus exporter to the list, the allocated
port is 9602.

//CC @richih @bastischubert

[1]
https://github.com/prometheus/prometheus/wiki/Default-port-allocations