### PR TITLE
*: Use Prometheus const metrics and implement Collector interface

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,11 +39,6 @@ func (c *Config) validate() error {
 	return nil
 }
 
-// HasModule returns whether the given config has a module with the given name.
-func (c *Config) HasModule(n string) bool {
-	return c.GetModule(n) != nil
-}
-
 // GetModule returns the module matching the given string or nil if none was
 // found.
 func (c *Config) GetModule(n string) *Module {

--- a/modbus_exporter_test.go
+++ b/modbus_exporter_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/lupoDharkael/modbus_exporter/config"
-	"github.com/lupoDharkael/modbus_exporter/modbus"
 )
 
 func TestScrapeHandler(t *testing.T) {
@@ -79,8 +78,6 @@ func TestScrapeHandler(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 			config := test.config()
-			exporter := modbus.NewExporter(config)
-
 			req, err := http.NewRequest("GET", "/metrics", nil)
 			if err != nil {
 				t.Fatal(err)
@@ -94,7 +91,7 @@ func TestScrapeHandler(t *testing.T) {
 
 			rr := httptest.NewRecorder()
 
-			scrapeHandler(exporter, rr, req)
+			scrapeHandler(config, rr, req)
 
 			if status := rr.Code; status != test.code {
 				t.Errorf(


### PR DESCRIPTION
With this commit modbus exporter uses prometheus.NewConstMetric and
implements the prometheus.Collector interface like the SNMP exporter
does.